### PR TITLE
Update SimpleJSON.cs

### DIFF
--- a/EGIoTKit.Utility/EGIoTKit.Utility/SimpleJSON.cs
+++ b/EGIoTKit.Utility/EGIoTKit.Utility/SimpleJSON.cs
@@ -40,7 +40,7 @@ namespace EGIoTKit.Utility
 
         void AddPre()
         {
-            if (sb.ToString() == "")
+            if (sb.Length == 0)
             {
                 sb.Append("{");
             }


### PR DESCRIPTION
When AddPre is executed first, sd.ToString() is null. Therefore, it corresponded to the bug to which not "{" but "," was set.
