### PR TITLE
値の先頭のダブルクォートが余分に付与される問題の解決

### DIFF
--- a/EGIoTKit.Utility/EGIoTKit.Utility/SimpleJSON.cs
+++ b/EGIoTKit.Utility/EGIoTKit.Utility/SimpleJSON.cs
@@ -51,7 +51,7 @@ namespace EGIoTKit.Utility
         }
         void AddKey(string key)
         {
-            sb.Append("\"" + key + "\":\"");
+            sb.Append("\"" + key + "\":");
         }
     }
 }


### PR DESCRIPTION
Addの多態性で値をダブルクォートでくくるかどうか判断しているのでそちらだけで問題なし
